### PR TITLE
Stochas 1.3.9

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.Stochas.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.Stochas.metainfo.xml
@@ -12,6 +12,7 @@
   <update_contact>_hub_AT_figuiere_net_</update_contact>
   <url type="homepage">https://stochas.org/</url>
   <releases>
+    <release version="1.3.9" date="2022-12-04"/>
     <release version="1.3.8" date="2022-11-21"/>
     <release version="1.3.5" date="2021-06-03"/>
     <release version="1.3.4" date="2020-11-01"/>

--- a/org.stochas.Stochas.json
+++ b/org.stochas.Stochas.json
@@ -34,8 +34,8 @@
             "name": "stochas",
             "buildsystem": "cmake-ninja",
             "config_opts": [
-                "-DSTOCHAS_VERSION=1.3.8",
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                "-DSTOCHAS_VERSION=1.3.9",
+                "-DCMAKE_BUILD_TYPE=Release"
             ],
             "cleanup": [
                 "/bin/JUCE-*",
@@ -43,12 +43,14 @@
                 "/include"
             ],
             "post-install": [
-                "install -Dm755 -t ${FLATPAK_DEST}/bin ./stochas_artefacts/RelWithDebInfo/Standalone/Stochas",
+                "install -Dm755 -t ${FLATPAK_DEST}/bin ./stochas_artefacts/Release/Standalone/Stochas",
                 "install -Dm644 image/app_logo_512.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png",
                 "install -Dm644 -t ${FLATPAK_DEST}/share/applications org.stochas.Stochas.desktop",
                 "install -Dm644 -t ${FLATPAK_DEST}/share/metainfo org.stochas.Stochas.metainfo.xml",
                 "install -d ${PLUGINS_DIR}/vst3",
-                "cp -r stochas_artefacts/RelWithDebInfo/VST3/*.vst3 ${PLUGINS_DIR}/vst3",
+                "cp -r stochas_artefacts/Release/VST3/*.vst3 ${PLUGINS_DIR}/vst3",
+                "#install -d ${PLUGINS_DIR}/clap",
+                "#cp -r stochas_artefacts/Release/CLAP/*.clap ${PLUGINS_DIR}/clap",
                 "install -Dm644 -t ${PLUGINS_DIR}/share/metainfo org.freedesktop.LinuxAudio.Plugins.Stochas.metainfo.xml",
                 "appstream-compose --basename=${PLUGINS_ID} --prefix=${PLUGINS_DIR} --origin=flatpak ${PLUGINS_ID}"
             ],
@@ -56,7 +58,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/surge-synthesizer/stochas.git",
-                    "tag": "v1.3.8"
+                    "tag": "v1.3.9"
                 },
                 {
                     "type": "file",

--- a/org.stochas.Stochas.metainfo.xml
+++ b/org.stochas.Stochas.metainfo.xml
@@ -55,6 +55,7 @@
   <url type="homepage">https://stochas.org/</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.3.9" date="2022-12-04"/>
     <release version="1.3.8" date="2022-11-21"/>
     <release version="1.3.5" date="2021-06-03"/>
     <release version="1.3.4" date="2020-11-01"/>


### PR DESCRIPTION
- Build Release.
- Don't install CLAP yet.